### PR TITLE
V1.0.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,17 @@
 # History
 
+## V1.0.0 (2025-05-23)
+Major breaking reworking resulting in version 1.
+* Adds Domain concept: Domain holds Places under string key names and can find any StudyQuery
+* Completes 'find' and 'send' functions which use StudyQuery (<place>:patient/study with wildcards).
+* Cleans up object responsibilities. ImagingStudy no longer holds any data except a key. Place can give info on its ImagingStudies.
+* Breaks loading of older settings files due to Place structure rewrite
+* Simplifies CLI functions by using domain.
+* Removes awkward SerializableXNATProjectPreArchive. Makes regular XNATProjectPreArchive serializable
+* Add additional medium verbosity level: DEBUG level dicomsync without ultra-verbose urlib3 clutter
+* Adds xnat server testing with mock pyxnat responses.
+
+
 ## v0.2.0 (2024-09-20)
 * Adds some CLI methods
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dicomsync"
-version = "1.0.0-beta1"
+version = "1.0.0"
 description = "Synchronize medical imaging studies between storage modalities"
 authors = ["sjoerdk <sjoerd.kerkstra@radboudumc.nl>"]
 license = "apache"


### PR DESCRIPTION
Major breaking reworking resulting in version 1.
* Adds Domain concept: Domain holds Places under string key names and can find any StudyQuery
* Completes 'find' and 'send' functions which use StudyQuery (<place>:patient/study with wildcards).
* Cleans up object responsibilities. ImagingStudy no longer holds any data except a key. Place can give info on its ImagingStudies.
* Breaks loading of older settings files due to Place structure rewrite
* Simplifies CLI functions by using domain.
* Removes awkward SerializableXNATProjectPreArchive. Makes regular XNATProjectPreArchive serializable
* Add additional medium verbosity level: DEBUG level dicomsync without ultra-verbose urlib3 clutter
* Adds xnat server testing with mock pyxnat responses.
